### PR TITLE
nil when thumbs are disabled

### DIFF
--- a/lib/el_finder/connector.rb
+++ b/lib/el_finder/connector.rb
@@ -409,7 +409,7 @@ module ElFinder
       else
         begin
           target.unlink
-          if (thumbnail = thumbnail_for(target)).file?
+          if @options[:thumbs] and (thumbnail = thumbnail_for(target)).file?
             thumbnail.unlink
           end
         rescue


### PR DESCRIPTION
With thumbs disabled,  @thumb_directory is nil and thumbnail_for will trigger a system exception (trying to call "+" on nil)  when called in "remove_target" - added a check if thumbs are enabled or not. Maybe this needs more checks in other methods..
