### PR TITLE
Prevent infinite loop if root path does not exist

### DIFF
--- a/lib/el_finder/connector.rb
+++ b/lib/el_finder/connector.rb
@@ -147,7 +147,7 @@ module ElFinder
 
       else
         @response[:error] = "Directory does not exist"
-        _open(@root)
+        _open(@root) if File.directory?(@root)
       end
 
     end # of open


### PR DESCRIPTION
Check that root path exists in Connector#_open, othervise _open method gets called infinitely
