### PR TITLE
Use of name parameter in ActionClass.el_finder

### DIFF
--- a/lib/el_finder/action.rb
+++ b/lib/el_finder/action.rb
@@ -9,7 +9,7 @@ module ElFinder
 
   module ActionClass
     def el_finder(name = :elfinder, &block)
-      self.send(:define_method, :elfinder) do
+      self.send(:define_method, name) do
         h, r = ElFinder::Connector.new(instance_eval(&block)).run(params)
         headers.merge!(h)
         render (r.empty? ? {:nothing => true} : {:text => r.to_json}), :layout => false


### PR DESCRIPTION
Looking at the method definition of ActionClass.el_finder, it seems that the name parameter should point to the method name to be generated in controller.

Currently the method definition call is like: self.send(:define_method, :elfinder)
It seems that it should be self.send(:define_method, name) otherwise name parameter is unused.
