### PR TITLE
Fixed file upload in Windows.

### DIFF
--- a/lib/el_finder/connector.rb
+++ b/lib/el_finder/connector.rb
@@ -243,7 +243,13 @@ module ElFinder
           @response[:errorData][@options[:original_filename_method].call(file)] = 'File exceeds the maximum allowed filesize'
         else
           dst = @current + @options[:original_filename_method].call(file)
-          src = file.respond_to?(:tempfile) ? file.tempfile.path : file.path
+          if file.respond_to?(:tempfile)
+            file.tempfile.close
+            src = file.tempfile.path
+          else
+            file.close
+            src = file.path
+          end
           FileUtils.mv(src, dst.fullpath)
           FileUtils.chmod @options[:upload_file_mode], dst
           select << to_hash(dst)


### PR DESCRIPTION
On windows systems, when Rack upload file to TEMP directory, leaves that file open. Moving open file is not allowed in windows. I have closed tempfile before FileUtils.mv.
