### PR TITLE
Remove duplicated key

### DIFF
--- a/lib/el_finder/pathname.rb
+++ b/lib/el_finder/pathname.rb
@@ -161,7 +161,6 @@ module ElFinder
       'file?'      => {:path => 'realpath', :rescue => true                             },
       'ftype'      => {:path => 'realpath',                                             },
       'mkdir'      => {:path => 'fullpath',                  :args => '(*args)'         },
-      'mkdir'      => {:path => 'fullpath',                  :args => '(*args)'         },
       'mtime'      => {:path => 'realpath',                                             },
       'open'       => {:path => 'fullpath',                  :args => '(*args, &block)' },
       'read'       => {:path => 'fullpath',                  :args => '(*args)'         },


### PR DESCRIPTION
`warning: duplicated key at line 164 ignored: "mkdir"` with Ruby 2.2