### PR TITLE
Prevent file handle leakage in Image.size

### DIFF
--- a/lib/el_finder/image.rb
+++ b/lib/el_finder/image.rb
@@ -10,7 +10,7 @@ module ElFinder
 
     def self.size(pathname)
       return nil unless File.exist?(pathname)
-      s = ::ImageSize.new(File.open(pathname)).size.to_s
+      s = ::ImageSize.path(pathname).size.to_s
       s = nil if s.empty?
       return s
     rescue


### PR DESCRIPTION
Using File.open and not closing the file handle delegates the cleanup to the garbage collector - it may run sometime in the future but might also not run at all when no memory pressure exists. See also http://stackoverflow.com/questions/4795447/rubys-file-open-and-the-need-for-f-close.

We have the situation that a unicorn process keeps open file handles during hours from this code and (using NFS) prevents deleting the folders as NFS keeps special files around when some process tries to delete a file another process still has an open file handle on (known as "silly rename").

Changing this to using `ImageSize.path(pathname).size` fixes this issue as no file handle is left open.
